### PR TITLE
Revert changes for the yanked 0.1.4 release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = farm_ng_package
-version = 0.1.4
+version = 0.1.5-dev
 description =
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -25,9 +25,7 @@ setup_requires =
     wheel
 
 install_requires =
-    grpcio==1.56.2
-    grpcio-tools==1.56.2
-    protobuf==4.23.4
+    grpcio-tools
 
 packages =
     farm_ng.package


### PR DESCRIPTION
Python CI in `farm-ng-amiga` builds from main branch of `farm-ng-package` (and `farm-ng-core`), which makes some sense, as we can use it to validate the build across all three packages before we start publishing releases. Clean this up so we don't have unwanted divergence between our CI and PyPI release jobs.